### PR TITLE
gh #6 Update HDMI CEC Interface

### DIFF
--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -135,6 +135,7 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * @note For HDMI source devices only, the logical address discovery also occurs in HdmiCecOpen() and
  * can be retrieved from HdmiCecGetLogicalAddress().
  * 
+ * @post HdmiCecClose() must be called to release resources.
  * @warning This API is NOT thread safe.
  *
  * @see HdmiCecClose()
@@ -368,9 +369,9 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  *                                                    CEC message to send.
  * @param[in] len                                 - Number of bytes in the message.
  * @param[out] result                             - send status buffer. Possible results are 
- *                    SENT_AND_ACKD,
- *                    SENT_BUT_NOT_ACKD (e.g. no follower at the destination),
- *                    SENT_FAILED (e.g. collision).
+ *                    HDMI_CEC_IO_SENT_AND_ACKD,
+ *                    HDMI_CEC_IO_SENT_BUT_NOT_ACKD (e.g. no follower at the destination),
+ *                    HDMI_CEC_IO_SENT_FAILED (e.g. collision).
  *
  * @return HDMI_CEC_STATUS                        - Status
  * @retval HDMI_CEC_IO_SUCCESS                    - Success

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -206,11 +206,13 @@ HDMI_CEC_STATUS HdmiCecAddLogicalAddress(int handle, int logicalAddresses);
  * @brief Clears the Logical Addresses claimed by the host device
  *
  * This function releases the previously acquired logical address.@n
- * Once released, the module must not ACK any POLL message destined to the
- * released address.@n
+ * Once released,
+ * 1. This API must set the logical address to the default value (0xF).
+ * 2. Also the module must not ACK any POLL message destined to the released address.@n
+ *
  * Subsequent calls to this API will return HDMI_CEC_IO_SUCCESS.
- * This API is only applicable for sink devices. Invoking this API in source 
- *  device must return HDMI_CEC_IO_INVALID_ARGUMENT@n@n
+ *
+ * This API is only applicable for sink devices. Invoking this API in source device must return HDMI_CEC_IO_INVALID_ARGUMENT@n@n
  * 
  *
  * @param[in] handle                   - The handle returned from the HdmiCecOpen(). Non zero value
@@ -221,7 +223,7 @@ HDMI_CEC_STATUS HdmiCecAddLogicalAddress(int handle, int logicalAddresses);
  * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid -
  *                                                  i.e. if any logical address less than 0x0 and greater than 0xF is given as argument
- * @retval HDMI_CEC_IO_NOT_ADDED                  - The default value set after removal is 0x0F
+ * @retval HDMI_CEC_IO_NOT_ADDED                  - Logical address was never added before [or] was previously removed successfully
  * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
  * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - Operation not supported. This API is not required if the SOC is performing the logical address discovery.
  *

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -220,8 +220,8 @@ HDMI_CEC_STATUS HdmiCecAddLogicalAddress(int handle, int logicalAddresses);
  * @retval HDMI_CEC_IO_SUCCESS                    - Success
  * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid -
- *                                                  i.e. if any logical address other than 0x0 is given as argument
- * @retval HDMI_CEC_IO_NOT_ADDED                  - 0x0 was never added before [or] 0x0 was previously removed successfully
+ *                                                  i.e. if any logical address less than 0x0 and greater than 0xF is given as argument
+ * @retval HDMI_CEC_IO_NOT_ADDED                  - The default value set after removal is 0x0F
  * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
  * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - Operation not supported. This API is not required if the SOC is performing the logical address discovery.
  *
@@ -397,31 +397,6 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  */
 HDMI_CEC_STATUS HdmiCecTx(int handle, const unsigned char *buf, int len, int *result);
 
-/**
- * @brief Writes CEC packet onto bus asynchronously.
- *
- * This function writes a complete CEC packet onto the bus but does not wait
- * for ACK. The result will be reported via HdmiCecRxCallback_t()
- *
- *
- * @param[in] handle                              - The handle returned from the 
- *                                                    HdmiCecOpen() function. Non zero value
- * @param[in] buf                                 - The buffer contains a complete 
- *                                                    CEC packet to send
- * @param[in] len                                 - Number of bytes in the packet
- *
- * @return HDMI_CEC_STATUS                        - Status
- * @retval HDMI_CEC_IO_SUCCESS                    - Success
- * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
- * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
- *
- * @pre  HdmiCecOpen(), HdmiCecSetRxCallback(), HdmiCecSetTxCallback()  should be called before calling this API.
- * @warning  This API is Not thread safe.
- * @see HdmiCecTx(), HdmiCecSetRxCallback()
- * 
- */
-HDMI_CEC_STATUS HdmiCecTxAsync(int handle, const unsigned char *buf, int len);
 #ifdef __cplusplus
 }
 #endif

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -121,6 +121,10 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  *
  * This function is required to be called before the other APIs in this module.@n
  * Subsequent calls to this API will return HDMI_CEC_IO_SUCCESS.
+ * For HDMI source devices, logical address discovery takes place during HdmiCecOpen() and
+ * can be obtained via HdmiCecGetLogicalAddress().
+ * For HDMI sink devices, logical address discovery does not occur during HdmiCecOpen() and
+ * must be managed by the caller.
  *
  * @param [out] handle                    - The handle used by application to uniquely 
  *                                          identify the HAL instance

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -170,10 +170,8 @@ HDMI_CEC_STATUS HdmiCecClose(int handle);
 /**
  * @brief Adds one Logical Addresses to be used by host device
  *
- * This function will block until the intended logical address is secured by the module.@n
- * HAL will forward all received messages with destination being the acquired logical address.@n
- * HAL should ACK all POLL messages destined to this logical address.@n
- * This API is only applicable for sink devices. Supported logical address value must be 0x0.@n
+ * Caller will take care of discovery of Logical Address and sets the available logical addresses through this API.@n
+ * This API is only applicable for sink devices.@n
  * Invoking this API in source device must return HDMI_CEC_IO_INVALID_ARGUMENT@n@n
  *
  * In HAL implementation, this API would trigger HAL sending a POLL CEC packet to the CEC Bus:@n
@@ -190,7 +188,7 @@ HDMI_CEC_STATUS HdmiCecClose(int handle);
  *                                                    ACK'd by any device on the bus
  * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
- *                                                  i.e. be if any logical address other than 0x0 is given as argument
+ *                                                  i.e. be if any logical address less than 0x0 and greater than 0xF is given as argument
  * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
  * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - POLL message is sent and 
  *                                                     ACK'd by a device on the bus
@@ -392,7 +390,7 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  *                                                    send an invalid logical address
  * @retval HDMI_CEC_IO_SENT_FAILED                - Send message failed
  *
- * @pre  HdmiCecOpen(), HdmiCecSetRxCallback() should be called before calling this API.
+ * @pre  HdmiCecOpen() should be called before calling this API.
  * @warning  This API is Not thread safe.
  * @see HdmiCecTxAsync(), HdmiCecSetRxCallback()
  * 

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -136,8 +136,6 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
  * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - Logical address is not available for source devices. 
  * 
- * @note For HDMI source devices only, the logical address discovery also occurs in HdmiCecOpen() and
- * can be retrieved from HdmiCecGetLogicalAddress().
  * 
  * @post HdmiCecClose() must be called to release resources.
  * @warning This API is NOT thread safe.


### PR DESCRIPTION
The Following changes are made in HDMI CEC HAL Interface documentation:

1. HdmiCecTx: HdmiCecSetRxCallback pre-requisite has to be removed

2. Supported logical address value must be 0x0. - to be removed from AddLogicaladdress

3. HdmiCecAddLogicalAddress

Description Update: "Caller will take care of discovery of Logical Address and set the available logical address through this API"

Remove :
 *This function will block until the intended logical address is secured by the module.@n
 * HAL will forward all received messages with destination being the acquired logical address.@n
 * HAL should ACK all POLL messages destined to this logical address.@n
 
 Supported logical address value must be 0x0 - to be removed

i.e. be if any logical address other than 0x0 is given as argument - to be changed as <0 and > 15 is invalid