### PR TITLE
gh #11 Modified the description of result param in HdmiCecTx

### DIFF
--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -389,7 +389,7 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  * @pre  HdmiCecOpen() should be called before calling this API.
  * @warning  This API is Not thread safe.
  * @see HdmiCecTxAsync(), HdmiCecSetRxCallback()
- * 
+ *
  */
 HDMI_CEC_STATUS HdmiCecTx(int handle, const unsigned char *buf, int len, int *result);
 

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -264,7 +264,7 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  *    The valid Physical address is less than F.F.F.F
  *    The Sink device at root will take 0.0.0.0 as the Physical Address
  * 
- * @pre HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only) must be called before calling this API.
+ * @pre HdmiCecOpen() must be called before calling this API.
  * @warning This API is NOT thread safe.
  * @see HdmiCecGetLogicalAddress()
  *

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -321,7 +321,7 @@ HDMI_CEC_STATUS HdmiCecGetPhysicalAddress(int handle, unsigned int *physicalAddr
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  *
- * @pre HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only) must be called before calling this API.
+ * @pre HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices and only for receiving directly addressed CEC messages) must be called before calling this API.
  * @warning This API is NOT thread safe.
  * @see HdmiCecTx(), HdmiCecTxAsync(), HdmiCecSetTxCallback()
  * 
@@ -386,7 +386,7 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  *                                                    send an invalid logical address
  * @retval HDMI_CEC_IO_SENT_FAILED                - Send message failed
  *
- * @pre  HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only) should be called before calling this API.
+ * @pre  HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only for all messages except Poll) should be called before calling this API.
  * @warning  This API is Not thread safe.
  * @see HdmiCecTxAsync(), HdmiCecSetRxCallback()
  * 

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -159,7 +159,7 @@ HDMI_CEC_STATUS HdmiCecOpen(int *handle);
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  *
- * @pre HdmiCecOpen() must be called before calling this API.
+ * @pre HdmiCecOpen(), HdmiCecRemoveLogicalAddress() must be called before calling this API.
  * @warning This API is NOT thread safe.
  *
  * @see HdmiCecOpen()
@@ -264,7 +264,7 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  *    The valid Physical address is less than F.F.F.F
  *    The Sink device at root will take 0.0.0.0 as the Physical Address
  * 
- * @pre HdmiCecOpen() must be called before calling this API.
+ * @pre HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only) must be called before calling this API.
  * @warning This API is NOT thread safe.
  * @see HdmiCecGetLogicalAddress()
  *
@@ -321,7 +321,7 @@ HDMI_CEC_STATUS HdmiCecGetPhysicalAddress(int handle, unsigned int *physicalAddr
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  *
- * @pre HdmiCecOpen() must be called before calling this API.
+ * @pre HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only) must be called before calling this API.
  * @warning This API is NOT thread safe.
  * @see HdmiCecTx(), HdmiCecTxAsync(), HdmiCecSetTxCallback()
  * 
@@ -386,7 +386,7 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  *                                                    send an invalid logical address
  * @retval HDMI_CEC_IO_SENT_FAILED                - Send message failed
  *
- * @pre  HdmiCecOpen() should be called before calling this API.
+ * @pre  HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only) should be called before calling this API.
  * @warning  This API is Not thread safe.
  * @see HdmiCecTxAsync(), HdmiCecSetRxCallback()
  * 

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -321,7 +321,7 @@ HDMI_CEC_STATUS HdmiCecGetPhysicalAddress(int handle, unsigned int *physicalAddr
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  *
- * @pre HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices and only for receiving directly addressed CEC messages) must be called before calling this API.
+ * @pre HdmiCecOpen() must be called before calling this API.
  * @warning This API is NOT thread safe.
  * @see HdmiCecTx(), HdmiCecTxAsync(), HdmiCecSetTxCallback()
  * 
@@ -370,7 +370,7 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  * @param[in] buf                                 - The buffer contains a complete 
  *                                                    CEC message to send.
  * @param[in] len                                 - Number of bytes in the message.
- * @param[out] result                             - send status buffer. Possible results are 
+ * @param[out] result                             - send status buffer. Possible results(valid only for directly addressed messages) are 
  *                    HDMI_CEC_IO_SENT_AND_ACKD,
  *                    HDMI_CEC_IO_SENT_BUT_NOT_ACKD (e.g. no follower at the destination),
  *                    HDMI_CEC_IO_SENT_FAILED (e.g. collision).
@@ -386,7 +386,7 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  *                                                    send an invalid logical address
  * @retval HDMI_CEC_IO_SENT_FAILED                - Send message failed
  *
- * @pre  HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only, for all messages except Poll) should be called before calling this API.
+ * @pre  HdmiCecOpen() should be called before calling this API.
  * @warning  This API is Not thread safe.
  * @see HdmiCecTxAsync(), HdmiCecSetRxCallback()
  * 

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -159,7 +159,7 @@ HDMI_CEC_STATUS HdmiCecOpen(int *handle);
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  *
- * @pre HdmiCecOpen(), HdmiCecRemoveLogicalAddress() must be called before calling this API.
+ * @pre HdmiCecOpen() must be called before calling this API.
  * @warning This API is NOT thread safe.
  *
  * @see HdmiCecOpen()

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -386,7 +386,7 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  *                                                    send an invalid logical address
  * @retval HDMI_CEC_IO_SENT_FAILED                - Send message failed
  *
- * @pre  HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only for all messages except Poll) should be called before calling this API.
+ * @pre  HdmiCecOpen(), HdmiCecAddLogicalAddress() (for sink devices only, for all messages except Poll) should be called before calling this API.
  * @warning  This API is Not thread safe.
  * @see HdmiCecTxAsync(), HdmiCecSetRxCallback()
  * 


### PR DESCRIPTION
Modified the description of result param in HdmiCecTx

The possible values for results like HDMI_CEC_IO_SENT_AND_ACKD, HDMI_CEC_IO_SENT_BUT_NOT_ACKD and HDMI_CEC_IO_SENT_FAILED is valid only for directly addressed CEC messages