### PR TITLE
XIONE-17095: Send HdmiCEC OTP message after DS wakeup

### DIFF
--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -419,6 +419,8 @@ HDMI_CEC_STATUS HdmiCecTx(int handle, const unsigned char *buf, int len, int *re
  *
  */
 HDMI_CEC_STATUS HdmiCecTxAsync(int handle, const unsigned char *buf, int len);
+
+HDMI_CEC_STATUS HdmiCecSendOTP(int handle);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Reason for change: [TESTING PURPOSE] [DO NOT MERGE] Try sending cec OTP after wakeup

Test Procedure: build and verify wakeup timings
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi srigayathry.pugazhenthi@sky.uk