### PR TITLE
gh #18 fix mermaid code space issue

### DIFF
--- a/docs/pages/hdmi-cec_halSpec.md
+++ b/docs/pages/hdmi-cec_halSpec.md
@@ -53,7 +53,7 @@ x[HDMI CEC HAL]-->z[HDMI CEC SOC Driver];
 style y fill:#99CCFF,stroke:#333,stroke-width:0.3px,align:left
 style z fill:#fcc,stroke:#333,stroke-width:0.3px,align:left
 style x fill:#9f9,stroke:#333,stroke-width:0.3px,align:left
- ```
+```
 
 This interface provides a set of `APIs` to facilitate communication through the driver for `CEC` messages with other `CEC` devices connected with HDMI cable.
 
@@ -218,4 +218,4 @@ NOTE: The module would operate deterministically if the above call sequence is f
     HAL->>Driver: Soc Un-initialises
     Driver-->>HAL:return
     HAL-->>Caller:return
- ```
+```


### PR DESCRIPTION
In file docs/pages/hdmi-cec_halSpec.md, the mermaid diagrams, end with an additional white space in their last line.
In the sections 'Description' and 'Interface API Documentation', there are mermaid formatted diagrams present. Instead of ```, they end with ``` . While this additional white space is not causing issues in GitHub, this is causing issues in some other markdown parsers like mkdocs

Removing the white space at the end of the diagram ( before the last ``` ) makes the diagrams render properly