### PR TITLE
Improving HAL spec clarity

### DIFF
--- a/docs/pages/hdmi-cec_halSpec.md
+++ b/docs/pages/hdmi-cec_halSpec.md
@@ -155,9 +155,11 @@ None
 
 The caller is expected to have complete control over the life cycle of the `HAL`.
 
-1. Initialize the `HAL` using function: `HdmiCecOpen()` before making any other `API` calls. This call also discovers the physical address based on the connection topology. In case of source devices, `HdmiCecOpen()` must initiate the logical address discovery as part of this routine. In case of sink devices, logical address will be fixed and set using the `HdmiCecAddLogicalAddress()`. If `HdmiCecOpen()` call fails, the `HAL` must return the respective error code, so that the caller can retry the operation.
+1. Initialize the `HAL` using function: `HdmiCecOpen()` before making any other `API` calls. This call also discovers the physical address based on the connection topology. In case of source devices, `HdmiCecOpen()` must initiate the logical address discovery as part of this routine. In case of sink devices, logical address will be fixed and set using the `HdmiCecAddLogicalAddress()`.
 
-2. Once logical address and physical address are assigned, the caller will be able to send and receive the respective `CEC` messages.
+2. If `HdmiCecOpen()` call fails, the `HAL` must release all allocated resources before returning errorcode so that the caller can retry the operation.
+
+3. Once logical address and physical address are assigned, the caller will be able to send and receive the respective `CEC` messages.
 
   - For asynchronous receive operations, use the callback function: `HdmiCecSetRxCallback()`. the caller must register a callback after initialisation.
 
@@ -165,7 +167,7 @@ The caller is expected to have complete control over the life cycle of the `HAL`
 
   - For asynchronous transmit, use the function: `HdmiCecTxAsync()`. The caller must register a callback via `HdmiCecSetTxCallback()` in order to receive the status or acknowledgement.
 
-3.De-intialise the `HAL` using the function: `HdmiCecClose()`.
+4.De-intialise the `HAL` using the function: `HdmiCecClose()`.
 
 NOTE: The module would operate deterministically if the above call sequence is followed.
 

--- a/docs/pages/hdmi-cec_halSpec.md
+++ b/docs/pages/hdmi-cec_halSpec.md
@@ -157,7 +157,7 @@ The caller is expected to have complete control over the life cycle of the `HAL`
 
 1. Initialize the `HAL` using function: `HdmiCecOpen()` before making any other `API` calls. This call also discovers the physical address based on the connection topology. In case of source devices, `HdmiCecOpen()` must initiate the logical address discovery as part of this routine. In case of sink devices, logical address will be fixed and set using the `HdmiCecAddLogicalAddress()`.
 
-2. If `HdmiCecOpen()` call fails, the `HAL` must release all allocated resources before returning errorcode so that the caller can retry the operation.
+2. If `HdmiCecOpen()` call fails, the `HAL` must release all allocated resources before returning an error code so that the caller can retry the operation.
 
 3. Once logical address and physical address are assigned, the caller will be able to send and receive the respective `CEC` messages.
 

--- a/docs/pages/hdmi-cec_halSpec.md
+++ b/docs/pages/hdmi-cec_halSpec.md
@@ -167,7 +167,7 @@ The caller is expected to have complete control over the life cycle of the `HAL`
 
   - For asynchronous transmit, use the function: `HdmiCecTxAsync()`. The caller must register a callback via `HdmiCecSetTxCallback()` in order to receive the status or acknowledgement.
 
-4.De-intialise the `HAL` using the function: `HdmiCecClose()`.
+4. De-initialise the `HAL` using the function: `HdmiCecClose()`.
 
 NOTE: The module would operate deterministically if the above call sequence is followed.
 

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -124,25 +124,32 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * can be obtained via HdmiCecGetLogicalAddress().@n
  * For HDMI sink devices, logical address discovery does not occur during HdmiCecOpen() and
  * must be managed by the caller.@n
- * A valid handle is returned only on HDMI_CEC_IO_SUCCESS; for all other return codes the
- * handle is invalid and HdmiCecClose() must not be called.
+ * A valid handle is returned on HDMI_CEC_IO_SUCCESS or HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE;
+ * HdmiCecClose() must be called in both cases to release resources.@n
+ * For all other return codes the handle is invalid and HdmiCecClose() must not be called.
  *
  * @param [out] handle                    - The handle used by application to uniquely 
  *                                          identify the HAL instance
  *
  * @return HDMI_CEC_STATUS                        - Status
- * @retval HDMI_CEC_IO_SUCCESS                    - Success
- * @retval HDMI_CEC_IO_ALREADY_OPEN               - Function is already open. 
- *                                                  This error code will deprecated in the next phase.
+ * @retval HDMI_CEC_IO_SUCCESS                    - Module opened and logical address assigned
+ *                                                  (source devices) or ready for logical address
+ *                                                  management (sink devices). On subsequent calls
+ *                                                  the same valid handle is returned and
+ *                                                  HdmiCecClose() must not be called again.
+ * @retval HDMI_CEC_IO_ALREADY_OPEN               - Function is already open.
+ *                                                  This error code will be deprecated in the next phase.
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
- * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - CEC bus is unavailable at open time
- *                                                  (e.g. no sink present for source devices,
- *                                                  or cable disconnected for any device type)
+ * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - Source devices only: logical address could
+ *                                                  not be acquired because no sink device is
+ *                                                  present on the CEC bus (e.g. cable
+ *                                                  disconnected or no connected display).
  * @retval HDMI_CEC_IO_GENERAL_ERROR              - Unexpected hardware or platform failure
  * 
  * 
- * @post HdmiCecClose() must be called to release resources. Applicable only when
- *       HDMI_CEC_IO_SUCCESS is returned.
+ * @post HdmiCecClose() must be called to release resources when HDMI_CEC_IO_SUCCESS is
+ *       returned (all device types). For source devices, HdmiCecClose() must also be
+ *       called when HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE is returned.
  * @warning This API is NOT thread safe.
  *
  * @see HdmiCecClose()

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -144,8 +144,7 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  *                                                  when HDMI_CEC_IO_SUCCESS is returned.
  * @return HDMI_CEC_STATUS                        - Status
  * @retval HDMI_CEC_IO_SUCCESS                    - Success
- * @retval HDMI_CEC_IO_ALREADY_OPEN               - This error code will be Deprecated in next phase.
-                                                    Module is already open.
+ * @retval HDMI_CEC_IO_ALREADY_OPEN               - Module is already open (deprecated; may be removed in a future release).
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Invalid argument passed to this function.
  *                                                  This includes a NULL handle parameter.
  * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - Logical address is not available for source devices.
@@ -212,7 +211,7 @@ HDMI_CEC_STATUS HdmiCecClose(int handle);
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - The logicalAddress argument is invalid.
  *                                                  Valid range is 0x0 to 0xF.
  * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle has been provided.
- * @retval HDMI_CEC_IO_GENERAL                    - Unable to verify logical address
+ * @retval HDMI_CEC_IO_GENERAL_ERROR              - Unable to verify logical address
  *                                                  availability due to a bus or connection error.
  * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - The requested operation is not supported
  *                                                  for the current device type (HDMI Source).
@@ -245,7 +244,7 @@ HDMI_CEC_STATUS HdmiCecAddLogicalAddress(int handle, int logicalAddresses);
  *
  * @param[in] handle                              - A Valid handle returned from the HdmiCecOpen().
  *                                                  must be a non zero value
- * @param[in] logicalAddresses                    - Logical address to be acquired.
+ * @param[in] logicalAddresses                    - Logical address to be released.
  *                                                  Valid range is 0x0 to 0xF.
  *
  * @return HDMI_CEC_STATUS                        - Status
@@ -262,8 +261,8 @@ HDMI_CEC_STATUS HdmiCecAddLogicalAddress(int handle, int logicalAddresses);
  * @pre HdmiCecAddLogicalAddress() must have been called successfully for the
  *      logical address before invoking this API.
  * @post On successful return, the logical address is released, the module is
-      reset to the default logical address (0xF), and the module shall not
-      acknowledge POLL messages for the released logical address.
+ *       reset to the default logical address (0xF), and the module shall not
+ *       acknowledge POLL messages for the released logical address.
  * @warning This API is NOT thread safe.
  * @see HdmiCecAddLogicalAddress(), HdmiCecGetLogicalAddress()
  * 
@@ -306,12 +305,13 @@ HDMI_CEC_STATUS HdmiCecRemoveLogicalAddress(int handle, int logicalAddresses);
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  *
  * @pre HdmiCecOpen() must be called successfully before calling this API.
+ * @pre For HDMI sink devices, HdmiCecAddLogicalAddress() must have been called
+ *      successfully and the specified logical address must be assigned before
+ *      invoking this API.
  *
  * @post On successful return, the logicalAddress output parameter contains the
  *       logical address assigned to the module.
- * @pre HdmiCecOpen() must be called before calling this API.
- * @pre HdmiCecAddLogicalAddress() must have been called successfully and the
- *      specified logical address must be assigned before invoking this API.
+ *
  * @warning This API is NOT thread safe.
  * @note This API is not required if the SOC is performing the logical address discovery.
  * @see HdmiCecAddLogicalAddress(), HdmiCecRemoveLogicalAddress()

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -147,9 +147,9 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * @retval HDMI_CEC_IO_GENERAL_ERROR              - Unexpected hardware or platform failure
  * 
  * 
- * @post HdmiCecClose() must be called to release resources when HDMI_CEC_IO_SUCCESS is
- *       returned (all device types). For source devices, HdmiCecClose() must also be
- *       called when HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE is returned.
+ * @post HdmiCecClose() must be called exactly once to release resources when a valid handle is returned:
+ *       HDMI_CEC_IO_SUCCESS (all device types) and, for source devices, also
+ *       HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE.
  * @warning This API is NOT thread safe.
  *
  * @see HdmiCecClose()

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -95,8 +95,10 @@ typedef enum HDMI_CEC_IO_ERROR
 /**
  * @brief Callback function triggered when a complete CEC message is received
  *
- * Upon each callback, only 1 complete message should be contained in the buffer.
- * The message data must be copied in the call because the buf pointer is no longer valid when this callback returns.
+ * Upon each callback, only one complete CEC message shall be contained in the buffer.
+ * The message data shall be copied by the receiver during the callback
+ * execution, as the buffer pointer shall no longer be valid after the callback
+ * returns.
  *
  * @param[in] handle       - The handle used by application to uniquely identify the HAL instance. Non zero value
  * @param[in] callbackData - Callback data for the receive callback
@@ -110,8 +112,9 @@ typedef void (*HdmiCecRxCallback_t)(int handle, void *callbackData, unsigned cha
  *
  * @brief Callback function triggered to report the status of the latest transmit message
  *
- * @param[in] handle       - The handle used by application to uniquely identify the HAL instance. Non zero value
- * @param[in] callbackData - Callback data for the transmit callback
+ * @param[in] handle       - The handle used by application to uniquely identify
+ *                           the HAL instance. The handle shall be valid (non zero).
+ * @param[in] callbackData - Callback data provided during callback registration
  * @param[in] result       - Async transmit result from the platform implementation
  */
 typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
@@ -120,39 +123,40 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * @brief Initializes the HDMI CEC HAL
  *
  * This function is required to be called before the other APIs in this module.@n
- * For HDMI source devices, logical address discovery takes place during HdmiCecOpen() and
- * can be obtained via HdmiCecGetLogicalAddress().@n
- * For HDMI sink devices, logical address discovery does not occur during HdmiCecOpen() and
- * must be managed by the caller.@n
- * A valid handle is returned on HDMI_CEC_IO_SUCCESS or HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE.@n
- * HdmiCecClose() must be called exactly once for that handle to release resources.@n
- * For all other return codes the handle is invalid and HdmiCecClose() must not be called.
+ * Subsequent calls to this API will return HDMI_CEC_IO_SUCCESS if the HAL is
+ * already initialized. Support for HDMI_CEC_IO_ALREADY_OPEN is deprecated and
+ * may be removed in a future release.
  *
- * @param [out] handle                    - The handle used by application to uniquely 
- *                                          identify the HAL instance
+ * HDMI Source devices:
+ * - Logical address discovery shall take place during HdmiCecOpen().
+ * - The allocated logical address can be obtained using HdmiCecGetLogicalAddress().
+ * - If logical address discovery fails,
+ *   HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE shall be returned and the HDMI-CEC
+ *   HAL instance shall release all allocated resources before returning.
  *
+ * HDMI Sink devices:
+ * - HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE shall not be returned.
+ * - Logical address discovery shall not be performed during HdmiCecOpen().
+ * - Logical address allocation and management shall be performed by the caller.
+ *
+ * @param [out] handle                            - The handle used by application to uniquely
+ *                                                  identify the HAL instance and valid only
+ *                                                  when HDMI_CEC_IO_SUCCESS is returned.
  * @return HDMI_CEC_STATUS                        - Status
- * @retval HDMI_CEC_IO_SUCCESS                    - Module opened and logical address assigned
- *                                                  (source devices) or ready for logical address
- *                                                  management (sink devices). On subsequent calls
- *                                                  the same valid handle is returned and
- *                                                  HdmiCecClose() must not be called again.
- * @retval HDMI_CEC_IO_ALREADY_OPEN               - Function is already open.
- *                                                  This error code will be deprecated in the next phase.
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
- * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - Source devices only: logical address could
- *                                                  not be acquired because no sink device is
- *                                                  present on the CEC bus (e.g. cable
- *                                                  disconnected or no connected display).
+ * @retval HDMI_CEC_IO_SUCCESS                    - Success
+ * @retval HDMI_CEC_IO_ALREADY_OPEN               - This error code will be Deprecated in next phase.
+                                                    Module is already open.
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Invalid argument passed to this function.
+ *                                                  This includes a NULL handle parameter.
+ * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - Logical address is not available for source devices.
  * @retval HDMI_CEC_IO_GENERAL_ERROR              - Unexpected hardware or platform failure
  * 
  * 
- * @post HdmiCecClose() must be called exactly once to release resources when a valid handle is returned:
- *       HDMI_CEC_IO_SUCCESS (all device types) and, for source devices, also
- *       HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE.
+ * @post HdmiCecClose() must be called to release resources.
  * @warning This API is NOT thread safe.
  *
  * @see HdmiCecClose()
+ *
  */
 HDMI_CEC_STATUS HdmiCecOpen(int *handle);
 
@@ -161,13 +165,16 @@ HDMI_CEC_STATUS HdmiCecOpen(int *handle);
  *
  * This function will uninitialise the module.@n
  * Close will clear up registered logical addresses.@n
- * Subsequent calls to this API will return HDMI_CEC_IO_NOT_OPENED.
+ * Subsequent calls to this API with the same handle will return
+ * HDMI_CEC_IO_NOT_OPENED.
  *
- * @param[in] handle - The handle returned from the HdmiCecOpen(). Non zero value
+ * @param[in] handle                    - A Valid handle returned from the HdmiCecOpen().
+ *                                        Should be non zero value
  *
  * @return HDMI_CEC_STATUS              - Status
  * @retval HDMI_CEC_IO_SUCCESS          - Success
- * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
+ * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised or the handle
+ *                                        has already been closed
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  * @retval HDMI_CEC_IO_GENERAL_ERROR    - Unexpected platform-level failure
  *
@@ -182,27 +189,42 @@ HDMI_CEC_STATUS HdmiCecClose(int handle);
 /**
  * @brief Sets the logical address assignment for a HDMI sink device.
  *
- * Caller will take care of discovery of Logical Address and sets the available logical addresses through this API.@n
- * This API is only applicable for sink devices.@n
- * Invoking this API in source device must return HDMI_CEC_IO_OPERATION_NOT_SUPPORTED@n@n
+ * HDMI Sink devices:
+ * - This API is applicable.
+ * - Logical address discovery shall be performed by the caller.
+ * - The logical address provided through this API shall be in the range
+ *   0x0 to 0xF.
  *
+ * HDMI Source devices:
+ * - This API is not applicable.
+ * - Invoking this API shall return HDMI_CEC_IO_OPERATION_NOT_SUPPORTED.
  *
- * @param[in] handle                              - The handle returned from the HdmiCecOpen() 
- *                                                    function. Non zero value
- * @param[in] logicalAddresses                    - The logical address to be acquired
- *
+ * @param[in] handle                              - A Valid handle returned from the HdmiCecOpen().
+ *                                                  must be a non zero value
+ * @param[in] logicalAddresses                    - Logical address to be acquired.
+ *                                                  Valid range is 0x0 to 0xF.
  * @return HDMI_CEC_STATUS                        - Status
- * @retval HDMI_CEC_IO_SUCCESS                    - POLL message is sent successfully and not 
- *                                                    ACK'd by any device on the bus
- * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
- *                                                  i.e. be if any logical address less than 0x0 and greater than 0xF is given as argument
- * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
- * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - The attempted operation is not supported
+ * @retval HDMI_CEC_IO_SUCCESS                    - POLL message is sent successfully and
+ *                                                  no device acknowledges the logical address
+ *                                                  on the CEC bus. The logical address is
+ *                                                  assigned successfully.
+ * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialized
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - The logicalAddress argument is invalid.
+ *                                                  Valid range is 0x0 to 0xF.
+ * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle has been provided.
+ * @retval HDMI_CEC_IO_GENERAL                    - Unable to verify logical address
+ *                                                  availability due to a bus or connection error.
+ * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - The requested operation is not supported
+ *                                                  for the current device type (HDMI Source).
  *
- * @pre HdmiCecOpen() must be called before calling this API.
- * @warning This API is NOT thread safe.
- * 
+ * @pre HdmiCecOpen() must be called successfully before invoking this API.
+ *
+ * @post On successful return, the logical address is assigned and can be retrieved using
+ *       HdmiCecGetLogicalAddress() and removed using HdmiCecRemoveLogicalAddress().
+ *
+ * @warning This API is not thread safe. The caller shall ensure proper synchronization
+ *          when invoking this API concurrently with other HDMI CEC APIs.
+ *
  * @see HdmiCecRemoveLogicalAddress(), HdmiCecGetLogicalAddress()
  */ 
 HDMI_CEC_STATUS HdmiCecAddLogicalAddress(int handle, int logicalAddresses);
@@ -210,30 +232,38 @@ HDMI_CEC_STATUS HdmiCecAddLogicalAddress(int handle, int logicalAddresses);
 /**
  * @brief Clears the Logical Addresses claimed by the host device
  *
- * This function releases the previously acquired logical address.@n
- * Once released,
- * 1. This API must set the logical address to the default value (0xF).
- * 2. Also the module must not ACK any POLL message destined to the released address.@n
+ * HDMI Sink devices:
+ * - This API is applicable and releases the previously assigned logical address.@n
+ * Once released:@n
+ * 1. This API shall set the logical address to the default value (0xF).@n
+ * 2. The module shall not ACK any POLL message destined for the released address.
  *
- *
- * This API is only applicable for sink devices. Invoking this API in source device must return HDMI_CEC_IO_OPERATION_NOT_SUPPORTED@n@n
+ * HDMI Source devices:
+ * - This API is not applicable.
+ * - Invoking this API shall return HDMI_CEC_IO_OPERATION_NOT_SUPPORTED.
  * 
  *
- * @param[in] handle                   - The handle returned from the HdmiCecOpen(). Non zero value
- * @param[in] logicalAddresses         - The logicalAddresses to be released
+ * @param[in] handle                              - A Valid handle returned from the HdmiCecOpen().
+ *                                                  must be a non zero value
+ * @param[in] logicalAddresses                    - Logical address to be acquired.
+ *                                                  Valid range is 0x0 to 0xF.
  *
  * @return HDMI_CEC_STATUS                        - Status
  * @retval HDMI_CEC_IO_SUCCESS                    - Success
  * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid -
- *                                                  i.e. if any logical address is outside the valid range [0x0, 0xF]
- *                                                  (less than 0x0 or greater than 0xF)
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - The logicalAddress argument is invalid.
+ *                                                  Valid range is 0x0 to 0xF.
  * @retval HDMI_CEC_IO_NOT_ADDED                  - Logical address was never added before [or] was previously removed successfully
- * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
- * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - Source devices only: returned immediately
- *                                                  without evaluating any other preconditions
+ * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle has been provided.
+ * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - The requested operation is not supported
+ *                                                  for the current device type (HDMI Source).
  *
- * @pre HdmiCecOpen() must be called before calling this API.
+ * @pre HdmiCecOpen() must be called successfully before calling this API.
+ * @pre HdmiCecAddLogicalAddress() must have been called successfully for the
+ *      logical address before invoking this API.
+ * @post On successful return, the logical address is released, the module is
+      reset to the default logical address (0xF), and the module shall not
+      acknowledge POLL messages for the released logical address.
  * @warning This API is NOT thread safe.
  * @see HdmiCecAddLogicalAddress(), HdmiCecGetLogicalAddress()
  * 
@@ -242,23 +272,46 @@ HDMI_CEC_STATUS HdmiCecRemoveLogicalAddress(int handle, int logicalAddresses);
 
 /**
  * @brief Gets the Logical Address obtained by the module
+*
+ * This function retrieves the logical address for the specified device type.@n
  *
- * This function gets the logical address for the specified device type. @n
- * For sink devices, if logical address is not added or removed, 
- *    the logical address returned will be 0x0F.
- * For source devices, logical address returned must be based on the device type
- *    as defined in HDMI Specification.
- * 
- * @param[in] handle                    - The handle returned from the HdmiCecOpen(). Non zero value
+ * For sink devices:
+ * - If no logical address has been assigned or the assigned logical address
+ *   has been removed, this API shall return the default value 0x0F.
+ *
+ * For source devices:
+ * - The returned logical address shall correspond to the device type as defined
+ *   in the HDMI Specification.
+ *
+ * @note This note applies to HDMI source devices only.
+ *       The HAL internally re-discovers and updates the logical address when an
+ *       HDMI hotplug-in event is detected (via an internal platform callback).
+ *       The caller does not need to re-invoke HdmiCecOpen() to trigger this;
+ *       a subsequent call to HdmiCecGetLogicalAddress() after the hotplug-in
+ *       event has been processed shall return the newly assigned address.
+ *
+ * @note After an HDMI hotplug-out event, the HAL shall reset the logical address
+ *       to the default value 0x0F. Calling this API while the HDMI cable is
+ *       disconnected shall return 0x0F.
+ *
+ * @param[in] handle                    - A Valid handle returned from the HdmiCecOpen().
+ *                                        must be a non zero value
  * @param[out] logicalAddress           - The logical address acquired
  *
  * @return HDMI_CEC_STATUS              - Status
  * @retval HDMI_CEC_IO_SUCCESS          - Success
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT - If logicalAddress pointer is NULL
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT - The logicalAddress argument is invalid
+ *                                        or is a NULL pointer.
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  *
+ * @pre HdmiCecOpen() must be called successfully before calling this API.
+ *
+ * @post On successful return, the logicalAddress output parameter contains the
+ *       logical address assigned to the module.
  * @pre HdmiCecOpen() must be called before calling this API.
+ * @pre HdmiCecAddLogicalAddress() must have been called successfully and the
+ *      specified logical address must be assigned before invoking this API.
  * @warning This API is NOT thread safe.
  * @note This API is not required if the SOC is performing the logical address discovery.
  * @see HdmiCecAddLogicalAddress(), HdmiCecRemoveLogicalAddress()
@@ -273,21 +326,52 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  *
  * This function gets the Physical address for the specified device type.
  *
- * @param[in] handle            - The handle returned from the HdmiCecOpen(). Non zero value
- * @param[out] physicalAddress  - Physical address acquired
- *    The valid Physical address is less than F.F.F.F
- *    The Sink device at root will take 0.0.0.0 as the Physical Address
- * 
- * @pre HdmiCecOpen() must be called before calling this API.
- * @warning This API is NOT thread safe.
- * @see HdmiCecGetLogicalAddress()
+ * HDMI Sink devices:
+ * - A sink device directly connected at the root shall have a fixed physical
+ *   address of 0.0.0.0.
+ * - The physical address shall not change due to HDMI hotplug events.
+ *
+ * HDMI Source devices:
+ * - The physical address shall be obtained from the connected HDMI topology.
+ * - After an HDMI hotplug-in event, the HAL shall internally re-discover the
+ *   physical address.
+ * - Until physical address discovery completes successfully, this API shall
+ *   return HDMI_CEC_IO_INVALID_OUTPUT.
+ * - After an HDMI hotplug-out event, the previously obtained physical address
+ *   shall be considered invalid.
+ *   This API shall return HDMI_CEC_IO_INVALID_OUTPUT until a new HDMI connection
+ *   is established and physical address discovery completes successfully.
+ *
+ * @param[in] handle                    - A Valid handle returned from the HdmiCecOpen().
+ *                                         must be a non zero value
+ * @param[out] physicalAddress          - Pointer to store the physical address
+ *                                       obtained by the module.
+ *                                       The valid physical address range is
+ *                                       0.0.0.0 to F.F.F.E.
+ *                                       A sink device connected directly at the
+ *                                       root shall have a physical address
+ *                                       of 0.0.0.0.
  *
  * @return HDMI_CEC_STATUS              - Status
  * @retval HDMI_CEC_IO_SUCCESS          - Success
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT - If physicalAddress pointer is NULL
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT - The physicalAddress argument is invalid
+ *                                        or is a NULL pointer.
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
- * @retval HDMI_CEC_IO_INVALID_OUTPUT   - Physical address can't be retrieved because it is outside the valid range
+ * @retval HDMI_CEC_IO_INVALID_OUTPUT   - Physical address cannot be retrieved. This includes:
+ *                                        the HDMI cable is not connected (source devices),
+ *                                        physical address discovery is still in progress
+ *                                        after a hotplug-in event, or the retrieved address
+ *                                        is outside the valid range (0.0.0.0 to F.F.F.E).
+ *
+ * @pre HdmiCecOpen() must be called successfully before calling this API.
+ *
+ * @post On successful return, the physicalAddress output parameter contains the
+ *       physical address obtained by the module.
+ *
+ * @warning This API is NOT thread safe.
+ *
+ * @see HdmiCecGetLogicalAddress()
  * 
  */
 HDMI_CEC_STATUS HdmiCecGetPhysicalAddress(int handle, unsigned int *physicalAddress);
@@ -322,12 +406,10 @@ HDMI_CEC_STATUS HdmiCecGetPhysicalAddress(int handle, unsigned int *physicalAddr
  *
  * When HdmiCecSetRxCallback() is called, it replaces the previous set cbfunc and data
  * values. Setting a value of (cbfunc=null) disables the callback.
- * All registered callbacks are deregistered by HdmiCecClose() and must be re-registered
- * after each subsequent HdmiCecOpen() call.
  *
  * This function will block if callback invocation is in progress.
  *
- * @param[in] handle                    - The handle returned from the HdmiCecOpen() function. Non zero value
+ * @param[in] handle                    - The handle returned from the HdmiCecOpen(() function. Non zero value
  * @param[in] cbfunc                    - Function pointer to be invoked 
  *                                          when a complete message is received
  * @param[in] data                      - Callback data
@@ -352,8 +434,6 @@ HDMI_CEC_STATUS HdmiCecSetRxCallback(int handle, HdmiCecRxCallback_t cbfunc, voi
  * This function sets a callback which will be invoked once the async transmit
  * result is available. This is only necessary if the caller chooses to transmit
  * the message asynchronously.
- * All registered callbacks are deregistered by HdmiCecClose() and must be re-registered
- * after each subsequent HdmiCecOpen() call.
  *
  * This function will block if callback invocation is in progress.
  *
@@ -375,54 +455,34 @@ HDMI_CEC_STATUS HdmiCecSetRxCallback(int handle, HdmiCecRxCallback_t cbfunc, voi
 HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, void *data);
 
 /**
- * @brief Synchronous transmit call
+ * @brief Transmits a CEC message synchronously.
  *
- * This function writes a complete CEC message onto the bus and waits for ACK.
+ * This function writes a complete CEC message onto the bus and waits for the
+ * transmission result.
  *
- * The message contained in the buffer will follow the format detailed in HdmiCecSetRxCallback_t().
- * (ref <HDMI Specification 1-4> Section <CEC 6.1>)
+ * The message contained in the buffer shall follow the format described in
+ * HdmiCecSetRxCallback().
+ * (Reference: HDMI Specification 1.4, Section 6.1)
  *
- * @note Two-step result check:
- *       1. Check the return value first — if it is not HDMI_CEC_IO_SUCCESS, the transmission
- *          was never attempted (API precondition failure) and the result out-parameter is
- *          undefined.
- *       2. If the return value is HDMI_CEC_IO_SUCCESS, inspect the result out-parameter for
- *          the CEC bus transmission outcome (for directly addressed messages only).
- *
- * @param[in] handle                              - The handle returned from the 
- *                                                    HdmiCecOpen() function. Non zero value
- * @param[in] buf                                 - The buffer contains a complete 
- *                                                    CEC message to send.
+ * @param[in] handle                              - Valid handle returned by HdmiCecOpen().
+ *                                                  Must be a non-zero value.
+ * @param[in] buf                                 - Buffer containing the complete
+ *                                                  CEC message to transmit.
  * @param[in] len                                 - Number of bytes in the message.
- * @param[out] result                             - CEC bus transmission outcome. Valid only when
- *                                                  the return value is HDMI_CEC_IO_SUCCESS and
- *                                                  the message is directly addressed (undefined
- *                                                  for broadcast messages). Possible values:
- *                    HDMI_CEC_IO_SENT_AND_ACKD      - message sent and acknowledged
- *                    HDMI_CEC_IO_SENT_BUT_NOT_ACKD  - message sent but not acknowledged
- *                                                     (e.g. no device at the destination address)
- *                    HDMI_CEC_IO_SENT_FAILED         - message could not be sent
- *                                                     (e.g. bus collision, cable not connected,
- *                                                     or platform did not confirm transmission
- *                                                     within an implementation-defined timeout)
+ * @param[out] result                             - Pointer to store the transmission result.
+ *                                                  Valid results are:
+ *                                                  HDMI_CEC_IO_SENT_AND_ACKD,
+ *                                                  HDMI_CEC_IO_SENT_BUT_NOT_ACKD,
+ *                                                  HDMI_CEC_IO_SENT_FAILED.
+ *                                                  Valid only for directly addressed
+ *                                                  messages.
  *
- * @return HDMI_CEC_STATUS                        - API call status (check before inspecting result)
- * @retval HDMI_CEC_IO_SUCCESS                    - Transmission attempted; inspect result for
- *                                                  the bus outcome
- * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised; transmission not
- *                                                  attempted, result is undefined
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid;
- *                                                  transmission not attempted, result is undefined
- * @retval HDMI_CEC_IO_INVALID_HANDLE             - Invalid handle; transmission not attempted,
- *                                                  result is undefined
- * @retval HDMI_CEC_IO_SENT_AND_ACKD              - Message sent and acknowledged (platform may
- *                                                  return bus outcome directly instead of SUCCESS)
- * @retval HDMI_CEC_IO_SENT_BUT_NOT_ACKD          - Message sent but not acknowledged (platform may
- *                                                  return bus outcome directly instead of SUCCESS)
- * @retval HDMI_CEC_IO_SENT_FAILED                - Message could not be sent (platform may
- *                                                  return bus outcome directly instead of SUCCESS)
- * @retval HDMI_CEC_IO_GENERAL_ERROR              - Underlying platform transport failed to
- *                                                  initiate transmission; *result is undefined
+ * @return HDMI_CEC_STATUS                        - Status
+ * @retval HDMI_CEC_IO_SUCCESS                    - Success
+ * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Invalid buffer, length, or result
+ *                                                  parameter.
+ * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
  *
  * @pre  HdmiCecOpen() should be called before calling this API.
  * @warning  This API is Not thread safe.
@@ -451,8 +511,6 @@ HDMI_CEC_STATUS HdmiCecTx(int handle, const unsigned char *buf, int len, int *re
  * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
  * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
- * @retval HDMI_CEC_IO_GENERAL_ERROR              - Underlying platform transport failed to
- *                                                  queue the message
  *
  * @pre  HdmiCecOpen(), HdmiCecSetRxCallback(), HdmiCecSetTxCallback()  should be called before calling this API.
  * @warning  This API is Not thread safe.

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -285,7 +285,7 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  * @return HDMI_CEC_STATUS              - Status
  * @retval HDMI_CEC_IO_SUCCESS          - Success
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT - if physicalAddress pointer is NULL
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT - If physicalAddress pointer is NULL
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  * @retval HDMI_CEC_IO_INVALID_OUTPUT   - Physical address can't be retrieved because it is outside the valid range
  * 

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -226,11 +226,12 @@ HDMI_CEC_STATUS HdmiCecAddLogicalAddress(int handle, int logicalAddresses);
  * @retval HDMI_CEC_IO_SUCCESS                    - Success
  * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid -
- *                                                  i.e. if any logical address less than 0x0 and greater than 0xF is given as argument
+ *                                                  i.e. if any logical address is outside the valid range [0x0, 0xF]
+ *                                                  (less than 0x0 or greater than 0xF)
  * @retval HDMI_CEC_IO_NOT_ADDED                  - Logical address was never added before [or] was previously removed successfully
  * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
- * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - Operation not supported. This API is not required if the SOC is performing the logical address discovery.
- *                                                  This operation is not supported in source devices.
+ * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - Source devices only: returned immediately
+ *                                                  without evaluating any other preconditions
  *
  * @pre HdmiCecOpen() must be called before calling this API.
  * @warning This API is NOT thread safe.
@@ -254,7 +255,7 @@ HDMI_CEC_STATUS HdmiCecRemoveLogicalAddress(int handle, int logicalAddresses);
  * @return HDMI_CEC_STATUS              - Status
  * @retval HDMI_CEC_IO_SUCCESS          - Success
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT - Parameter passed to this function is invalid
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT - If logicalAddress pointer is NULL
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  *
  * @pre HdmiCecOpen() must be called before calling this API.
@@ -271,10 +272,6 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  * @brief Gets the Physical Address obtained by the module
  *
  * This function gets the Physical address for the specified device type.
- * If the platform returns the unassigned sentinel value 0xF.F.F.F (0xFFFF), as
- * defined in HDMI 1.4b, or if the HDMI topology changes after HdmiCecOpen()
- * (for example, due to a hot-unplug event), HDMI_CEC_IO_INVALID_OUTPUT is
- * returned.
  *
  * @param[in] handle            - The handle returned from the HdmiCecOpen(). Non zero value
  * @param[out] physicalAddress  - Physical address acquired
@@ -288,7 +285,7 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  * @return HDMI_CEC_STATUS              - Status
  * @retval HDMI_CEC_IO_SUCCESS          - Success
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT - Parameter passed to this function is invalid
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT - if physicalAddress pointer is NULL
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  * @retval HDMI_CEC_IO_INVALID_OUTPUT   - Physical address can't be retrieved because it is outside the valid range
  * 
@@ -339,7 +336,6 @@ HDMI_CEC_STATUS HdmiCecGetPhysicalAddress(int handle, unsigned int *physicalAddr
  * @retval HDMI_CEC_IO_SUCCESS          - Success
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT - if data is invalid or null.
  *
  * @pre HdmiCecOpen() must be called before calling this API.
  * @warning This API is NOT thread safe.
@@ -370,7 +366,6 @@ HDMI_CEC_STATUS HdmiCecSetRxCallback(int handle, HdmiCecRxCallback_t cbfunc, voi
  * @retval HDMI_CEC_IO_SUCCESS          - Success
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT - if data is invalid or null.
  *
  * @pre HdmiCecOpen() must be called before calling this API.
  * @warning This API is NOT thread safe.

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -82,7 +82,7 @@ typedef enum HDMI_CEC_IO_ERROR
     HDMI_CEC_IO_INVALID_ARGUMENT,           ///< Invalid argument is passed to the module
     HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE, ///< Logical address is not available
     HDMI_CEC_IO_GENERAL_ERROR,              ///< Operation general error.
-    HDMI_CEC_IO_ALREADY_OPEN,               ///< @deprecated Module is already initialised
+    HDMI_CEC_IO_ALREADY_OPEN,               ///< Module is already initialised
     HDMI_CEC_IO_ALREADY_REMOVED,            ///< Removal operation is already executed
     HDMI_CEC_IO_INVALID_OUTPUT,             ///< Output arguments fall outside the valid range
     HDMI_CEC_IO_INVALID_HANDLE,             ///< An invalid handle argument has been passed
@@ -124,9 +124,8 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * @brief Initializes the HDMI CEC HAL
  *
  * This function is required to be called before the other APIs in this module.@n
- * Subsequent calls to this API will return HDMI_CEC_IO_SUCCESS if the HAL is
- * already initialized. Support for HDMI_CEC_IO_ALREADY_OPEN is deprecated and
- * may be removed in a future release.
+ * Subsequent calls to this API will return HDMI_CEC_IO_ALREADY_OPEN if the HAL is
+ * already initialized.
  *
  * HDMI Source devices:
  * - Logical address discovery shall take place during HdmiCecOpen().
@@ -153,7 +152,7 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  *                                                  when HDMI_CEC_IO_SUCCESS is returned.
  * @return HDMI_CEC_STATUS                        - Status
  * @retval HDMI_CEC_IO_SUCCESS                    - Success
- * @retval HDMI_CEC_IO_ALREADY_OPEN               - Module is already open (deprecated; may be removed in a future release).
+ * @retval HDMI_CEC_IO_ALREADY_OPEN               - Module is already open.
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Invalid argument passed to this function.
  *                                                  This includes a NULL handle parameter.
  * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - Logical address is not available for source devices.

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -120,11 +120,12 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * @brief Initializes the HDMI CEC HAL
  *
  * This function is required to be called before the other APIs in this module.@n
- * Subsequent calls to this API will return HDMI_CEC_IO_SUCCESS.
  * For HDMI source devices, logical address discovery takes place during HdmiCecOpen() and
- * can be obtained via HdmiCecGetLogicalAddress().
+ * can be obtained via HdmiCecGetLogicalAddress().@n
  * For HDMI sink devices, logical address discovery does not occur during HdmiCecOpen() and
- * must be managed by the caller.
+ * must be managed by the caller.@n
+ * A valid handle is returned only on HDMI_CEC_IO_SUCCESS; for all other return codes the
+ * handle is invalid and HdmiCecClose() must not be called.
  *
  * @param [out] handle                    - The handle used by application to uniquely 
  *                                          identify the HAL instance
@@ -134,30 +135,40 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * @retval HDMI_CEC_IO_ALREADY_OPEN               - Function is already open. 
  *                                                  This error code will deprecated in the next phase.
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
- * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - Logical address is not available for source devices. 
+ * @retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE - CEC bus is unavailable at open time
+ *                                                  (e.g. no sink present for source devices,
+ *                                                  or cable disconnected for any device type)
+ * @retval HDMI_CEC_IO_GENERAL_ERROR              - Unexpected hardware or platform failure
  * 
  * 
- * @post HdmiCecClose() must be called to release resources.
+ * @post HdmiCecClose() must be called to release resources. Applicable only when
+ *       HDMI_CEC_IO_SUCCESS is returned.
  * @warning This API is NOT thread safe.
  *
  * @see HdmiCecClose()
- *
  */
 HDMI_CEC_STATUS HdmiCecOpen(int *handle);
 
 /**
  * @brief Closes an instance of HDMI CEC HAL
  *
- * This function will uninitialise the module.@n
- * Close will clear up registered logical addresses.@n
- * Subsequent calls to this API will return HDMI_CEC_IO_SUCCESS.
+ * This function uninitialises the module, clears all registered logical addresses,
+ * and deregisters all callbacks.@n
+ * This function succeeds regardless of HDMI cable connection state for all device types.@n
+ * For source devices, it is safe to call from an HPD (Hot Plug Detect) event handler;
+ * middleware is expected to call HdmiCecClose() on every HPD event and reinitialise
+ * from scratch via HdmiCecOpen().
  *
  * @param[in] handle - The handle returned from the HdmiCecOpen(). Non zero value
  *
  * @return HDMI_CEC_STATUS              - Status
  * @retval HDMI_CEC_IO_SUCCESS          - Success
- * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
+ * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not open: HdmiCecOpen() was never called,
+ *                                        the last HdmiCecOpen() did not return
+ *                                        HDMI_CEC_IO_SUCCESS, or HdmiCecClose() has
+ *                                        already been called successfully
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
+ * @retval HDMI_CEC_IO_GENERAL_ERROR    - Unexpected platform-level failure
  *
  * @pre HdmiCecOpen() must be called before calling this API.
  * @warning This API is NOT thread safe.
@@ -259,6 +270,10 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  * @brief Gets the Physical Address obtained by the module
  *
  * This function gets the Physical address for the specified device type.
+ * If the platform returns the unassigned sentinel value 0xF.F.F.F (0xFFFF), as
+ * defined in HDMI 1.4b, or if the HDMI topology changes after HdmiCecOpen()
+ * (for example, due to a hot-unplug event), HDMI_CEC_IO_INVALID_OUTPUT is
+ * returned.
  *
  * @param[in] handle            - The handle returned from the HdmiCecOpen(). Non zero value
  * @param[out] physicalAddress  - Physical address acquired
@@ -309,10 +324,12 @@ HDMI_CEC_STATUS HdmiCecGetPhysicalAddress(int handle, unsigned int *physicalAddr
  *
  * When HdmiCecSetRxCallback() is called, it replaces the previous set cbfunc and data
  * values. Setting a value of (cbfunc=null) disables the callback.
+ * All registered callbacks are deregistered by HdmiCecClose() and must be re-registered
+ * after each subsequent HdmiCecOpen() call.
  *
  * This function will block if callback invocation is in progress.
  *
- * @param[in] handle                    - The handle returned from the HdmiCecOpen(() function. Non zero value
+ * @param[in] handle                    - The handle returned from the HdmiCecOpen() function. Non zero value
  * @param[in] cbfunc                    - Function pointer to be invoked 
  *                                          when a complete message is received
  * @param[in] data                      - Callback data
@@ -321,6 +338,7 @@ HDMI_CEC_STATUS HdmiCecGetPhysicalAddress(int handle, unsigned int *physicalAddr
  * @retval HDMI_CEC_IO_SUCCESS          - Success
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT - if data is invalid or null.
  *
  * @pre HdmiCecOpen() must be called before calling this API.
  * @warning This API is NOT thread safe.
@@ -337,6 +355,8 @@ HDMI_CEC_STATUS HdmiCecSetRxCallback(int handle, HdmiCecRxCallback_t cbfunc, voi
  * This function sets a callback which will be invoked once the async transmit
  * result is available. This is only necessary if the caller chooses to transmit
  * the message asynchronously.
+ * All registered callbacks are deregistered by HdmiCecClose() and must be re-registered
+ * after each subsequent HdmiCecOpen() call.
  *
  * This function will block if callback invocation is in progress.
  *
@@ -349,6 +369,7 @@ HDMI_CEC_STATUS HdmiCecSetRxCallback(int handle, HdmiCecRxCallback_t cbfunc, voi
  * @retval HDMI_CEC_IO_SUCCESS          - Success
  * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT - if data is invalid or null.
  *
  * @pre HdmiCecOpen() must be called before calling this API.
  * @warning This API is NOT thread safe.
@@ -365,27 +386,43 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  * The message contained in the buffer will follow the format detailed in HdmiCecSetRxCallback_t().
  * (ref <HDMI Specification 1-4> Section <CEC 6.1>)
  *
+ * @note Two-step result check:
+ *       1. Check the return value first — if it is not HDMI_CEC_IO_SUCCESS, the transmission
+ *          was never attempted (API precondition failure) and the result out-parameter is
+ *          undefined.
+ *       2. If the return value is HDMI_CEC_IO_SUCCESS, inspect the result out-parameter for
+ *          the CEC bus transmission outcome (for directly addressed messages only).
  *
  * @param[in] handle                              - The handle returned from the 
  *                                                    HdmiCecOpen() function. Non zero value
  * @param[in] buf                                 - The buffer contains a complete 
  *                                                    CEC message to send.
  * @param[in] len                                 - Number of bytes in the message.
- * @param[out] result                             - send status buffer. Possible results(valid only for directly addressed messages) are 
- *                    HDMI_CEC_IO_SENT_AND_ACKD,
- *                    HDMI_CEC_IO_SENT_BUT_NOT_ACKD (e.g. no follower at the destination),
- *                    HDMI_CEC_IO_SENT_FAILED (e.g. collision).
+ * @param[out] result                             - CEC bus transmission outcome. Valid only when
+ *                                                  the return value is HDMI_CEC_IO_SUCCESS and
+ *                                                  the message is directly addressed (undefined
+ *                                                  for broadcast messages). Possible values:
+ *                    HDMI_CEC_IO_SENT_AND_ACKD      - message sent and acknowledged
+ *                    HDMI_CEC_IO_SENT_BUT_NOT_ACKD  - message sent but not acknowledged
+ *                                                     (e.g. no device at the destination address)
+ *                    HDMI_CEC_IO_SENT_FAILED         - message could not be sent
+ *                                                     (e.g. bus collision or cable not connected)
  *
- * @return HDMI_CEC_STATUS                        - Status
- * @retval HDMI_CEC_IO_SUCCESS                    - Success
- * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
- * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
- * @retval HDMI_CEC_IO_SENT_AND_ACKD              - Cec message is send and acknowledged.
- * @retval HDMI_CEC_IO_SENT_BUT_NOT_ACKD          - Message sent but not acknowledged 
- *                                                    by the receiver. Host device is trying to 
- *                                                    send an invalid logical address
- * @retval HDMI_CEC_IO_SENT_FAILED                - Send message failed
+ * @return HDMI_CEC_STATUS                        - API call status (check before inspecting result)
+ * @retval HDMI_CEC_IO_SUCCESS                    - Transmission attempted; inspect result for
+ *                                                  the bus outcome
+ * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised; transmission not
+ *                                                  attempted, result is undefined
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid;
+ *                                                  transmission not attempted, result is undefined
+ * @retval HDMI_CEC_IO_INVALID_HANDLE             - Invalid handle; transmission not attempted,
+ *                                                  result is undefined
+ * @retval HDMI_CEC_IO_SENT_AND_ACKD              - Message sent and acknowledged (platform may
+ *                                                  return bus outcome directly instead of SUCCESS)
+ * @retval HDMI_CEC_IO_SENT_BUT_NOT_ACKD          - Message sent but not acknowledged (platform may
+ *                                                  return bus outcome directly instead of SUCCESS)
+ * @retval HDMI_CEC_IO_SENT_FAILED                - Message could not be sent (platform may
+ *                                                  return bus outcome directly instead of SUCCESS)
  *
  * @pre  HdmiCecOpen() should be called before calling this API.
  * @warning  This API is Not thread safe.

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -124,8 +124,8 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * can be obtained via HdmiCecGetLogicalAddress().@n
  * For HDMI sink devices, logical address discovery does not occur during HdmiCecOpen() and
  * must be managed by the caller.@n
- * A valid handle is returned on HDMI_CEC_IO_SUCCESS or HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE;
- * HdmiCecClose() must be called in both cases to release resources.@n
+ * A valid handle is returned on HDMI_CEC_IO_SUCCESS or HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE.@n
+ * HdmiCecClose() must be called exactly once for that handle to release resources.@n
  * For all other return codes the handle is invalid and HdmiCecClose() must not be called.
  *
  * @param [out] handle                    - The handle used by application to uniquely 

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -130,9 +130,17 @@ typedef void (*HdmiCecTxCallback_t)(int handle, void *callbackData, int result);
  * HDMI Source devices:
  * - Logical address discovery shall take place during HdmiCecOpen().
  * - The allocated logical address can be obtained using HdmiCecGetLogicalAddress().
- * - If logical address discovery fails,
- *   HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE shall be returned and the HDMI-CEC
- *   HAL instance shall release all allocated resources before returning.
+ *
+ * @note This note applies to HDMI source devices only.
+ *       The HAL internally re-discovers and updates the logical address when an
+ *       HDMI connect state change event is detected (via an internal platform callback).
+ *       The caller does not need to re-invoke HdmiCecOpen() to trigger this;
+ *       a subsequent call to HdmiCecGetLogicalAddress() after the HDMI connect
+ *       state change event has been processed shall return the newly assigned address.
+ *
+ * @note After an HDMI disconnect state change event, the HAL shall reset the logical address
+ *       to the default value 0x0F. HdmiCecGetLogicalAddress() while the HDMI
+ *       cable is disconnected shall return 0x0F.
  *
  * HDMI Sink devices:
  * - HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE shall not be returned.
@@ -188,28 +196,33 @@ HDMI_CEC_STATUS HdmiCecClose(int handle);
 /**
  * @brief Sets the logical address assignment for a HDMI sink device.
  *
- * HDMI Sink devices:
+ * @par HDMI Sink devices
  * - This API is applicable.
  * - Logical address discovery shall be performed by the caller.
- * - The logical address provided through this API shall be in the range
- *   0x0 to 0xF.
+ * - Valid logical address values are defined by the HDMI CEC specification
+ *   for the Primary Device Type:
+ *   - 0  (TV)           : TV device at Physical Address 0.0.0.0
+ *   - 14 (Specific Use) : TV device at any other Physical Address, or as
+ *                         fallback when address 0 is unavailable
+ *   - 15 (Unregistered) : fallback when neither address 0 nor 14 can be
+ *                         allocated
  *
- * HDMI Source devices:
+ * @par HDMI Source devices
  * - This API is not applicable.
  * - Invoking this API shall return HDMI_CEC_IO_OPERATION_NOT_SUPPORTED.
  *
  * @param[in] handle                              - A Valid handle returned from the HdmiCecOpen().
  *                                                  must be a non zero value
  * @param[in] logicalAddresses                    - Logical address to be acquired.
- *                                                  Valid range is 0x0 to 0xF.
+ *                                                  See HDMI Sink devices section above for valid values.
  * @return HDMI_CEC_STATUS                        - Status
  * @retval HDMI_CEC_IO_SUCCESS                    - POLL message is sent successfully and
  *                                                  no device acknowledges the logical address
  *                                                  on the CEC bus. The logical address is
  *                                                  assigned successfully.
  * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialized
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - The logicalAddress argument is invalid.
- *                                                  Valid range is 0x0 to 0xF.
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Invalid logicalAddress argument.
+ *                                                  See logicalAddresses @param for valid values.
  * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle has been provided.
  * @retval HDMI_CEC_IO_GENERAL_ERROR              - Unable to verify logical address
  *                                                  availability due to a bus or connection error.
@@ -244,14 +257,13 @@ HDMI_CEC_STATUS HdmiCecAddLogicalAddress(int handle, int logicalAddresses);
  *
  * @param[in] handle                              - A Valid handle returned from the HdmiCecOpen().
  *                                                  must be a non zero value
- * @param[in] logicalAddresses                    - Logical address to be released.
- *                                                  Valid range is 0x0 to 0xF.
+ * @param[in] logicalAddresses                    - Previously assigned logical address to be released.
  *
  * @return HDMI_CEC_STATUS                        - Status
  * @retval HDMI_CEC_IO_SUCCESS                    - Success
  * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
- * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - The logicalAddress argument is invalid.
- *                                                  Valid range is 0x0 to 0xF.
+ * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Invalid logicalAddress argument.
+ *                                                  See logicalAddresses @param for valid values.
  * @retval HDMI_CEC_IO_NOT_ADDED                  - Logical address was never added before [or] was previously removed successfully
  * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle has been provided.
  * @retval HDMI_CEC_IO_OPERATION_NOT_SUPPORTED    - The requested operation is not supported
@@ -282,16 +294,8 @@ HDMI_CEC_STATUS HdmiCecRemoveLogicalAddress(int handle, int logicalAddresses);
  * - The returned logical address shall correspond to the device type as defined
  *   in the HDMI Specification.
  *
- * @note This note applies to HDMI source devices only.
- *       The HAL internally re-discovers and updates the logical address when an
- *       HDMI hotplug-in event is detected (via an internal platform callback).
- *       The caller does not need to re-invoke HdmiCecOpen() to trigger this;
- *       a subsequent call to HdmiCecGetLogicalAddress() after the hotplug-in
- *       event has been processed shall return the newly assigned address.
- *
- * @note After an HDMI hotplug-out event, the HAL shall reset the logical address
- *       to the default value 0x0F. Calling this API while the HDMI cable is
- *       disconnected shall return 0x0F.
+ * @note For HDMI source device HDMI state change re-discovery and reset behaviour,
+ *       refer to the HdmiCecOpen() documentation.
  *
  * @param[in] handle                    - A Valid handle returned from the HdmiCecOpen().
  *                                        must be a non zero value
@@ -329,15 +333,15 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  * HDMI Sink devices:
  * - A sink device directly connected at the root shall have a fixed physical
  *   address of 0.0.0.0.
- * - The physical address shall not change due to HDMI hotplug events.
+ * - The physical address shall not change due to HDMI state change events.
  *
  * HDMI Source devices:
  * - The physical address shall be obtained from the connected HDMI topology.
- * - After an HDMI hotplug-in event, the HAL shall internally re-discover the
+ * - After an HDMI connect state change event, the HAL shall internally re-discover the
  *   physical address.
  * - Until physical address discovery completes successfully, this API shall
  *   return HDMI_CEC_IO_INVALID_OUTPUT.
- * - After an HDMI hotplug-out event, the previously obtained physical address
+ * - After an HDMI disconnect state change event, the previously obtained physical address
  *   shall be considered invalid.
  *   This API shall return HDMI_CEC_IO_INVALID_OUTPUT until a new HDMI connection
  *   is established and physical address discovery completes successfully.
@@ -361,7 +365,7 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  * @retval HDMI_CEC_IO_INVALID_OUTPUT   - Physical address cannot be retrieved. This includes:
  *                                        the HDMI cable is not connected (source devices),
  *                                        physical address discovery is still in progress
- *                                        after a hotplug-in event, or the retrieved address
+ *                                        after an HDMI connect state change event, or the retrieved address
  *                                        is outside the valid range (0.0.0.0 to F.F.F.E).
  *
  * @pre HdmiCecOpen() must be called successfully before calling this API.

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -78,11 +78,11 @@ typedef enum HDMI_CEC_IO_ERROR
     HDMI_CEC_IO_SENT_AND_ACKD = 1,          ///< Send and acknowledgement received
     HDMI_CEC_IO_SENT_BUT_NOT_ACKD,          ///< Sent but acknowledgement not received
     HDMI_CEC_IO_SENT_FAILED,                ///< Operation failed
-    HDMI_CEC_IO_NOT_OPENED,                 ///< Module is not initialised
+    HDMI_CEC_IO_NOT_OPENED,                 ///< Module is not open. will be removed in a future release.
     HDMI_CEC_IO_INVALID_ARGUMENT,           ///< Invalid argument is passed to the module
     HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE, ///< Logical address is not available
     HDMI_CEC_IO_GENERAL_ERROR,              ///< Operation general error.
-    HDMI_CEC_IO_ALREADY_OPEN,               ///< Module is already initialised
+    HDMI_CEC_IO_ALREADY_OPEN,               ///< @deprecated Module is already initialised
     HDMI_CEC_IO_ALREADY_REMOVED,            ///< Removal operation is already executed
     HDMI_CEC_IO_INVALID_OUTPUT,             ///< Output arguments fall outside the valid range
     HDMI_CEC_IO_INVALID_HANDLE,             ///< An invalid handle argument has been passed
@@ -108,7 +108,8 @@ typedef enum HDMI_CEC_IO_ERROR
 typedef void (*HdmiCecRxCallback_t)(int handle, void *callbackData, unsigned char *buf, int len);
 
 /**
- * @note This API is deprecated.
+ * @deprecated Use HdmiCecSetRxCallback() to receive async transmit status.
+ *             This callback type will be removed in a future release.
  *
  * @brief Callback function triggered to report the status of the latest transmit message
  *
@@ -331,30 +332,26 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  * This function gets the Physical address for the specified device type.
  *
  * HDMI Sink devices:
- * - A sink device directly connected at the root shall have a fixed physical
- *   address of 0.0.0.0.
+ * - A sink device that is the CEC root (has no HDMI output) shall have a
+ *   fixed physical address of 0.0.0.0.
  * - The physical address shall not change due to HDMI state change events.
  *
  * HDMI Source devices:
  * - The physical address shall be obtained from the connected HDMI topology.
  * - After an HDMI connect state change event, the HAL shall internally re-discover the
  *   physical address.
- * - Until physical address discovery completes successfully, this API shall
- *   return HDMI_CEC_IO_INVALID_OUTPUT.
  * - After an HDMI disconnect state change event, the previously obtained physical address
  *   shall be considered invalid.
- *   This API shall return HDMI_CEC_IO_INVALID_OUTPUT until a new HDMI connection
- *   is established and physical address discovery completes successfully.
  *
  * @param[in] handle                    - A Valid handle returned from the HdmiCecOpen().
  *                                         must be a non zero value
  * @param[out] physicalAddress          - Pointer to store the physical address
- *                                       obtained by the module.
- *                                       The valid physical address range is
- *                                       0.0.0.0 to F.F.F.E.
- *                                       A sink device connected directly at the
- *                                       root shall have a physical address
- *                                       of 0.0.0.0.
+ *                                         obtained by the module.
+ *                                        The valid physical address range is
+ *                                          0.0.0.0 to F.F.F.E.
+ *                                        A sink device connected directly at the
+ *                                         root shall have a physical address
+ *                                         of 0.0.0.0.
  *
  * @return HDMI_CEC_STATUS              - Status
  * @retval HDMI_CEC_IO_SUCCESS          - Success
@@ -362,11 +359,11 @@ HDMI_CEC_STATUS HdmiCecGetLogicalAddress(int handle, int *logicalAddress);
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT - The physicalAddress argument is invalid
  *                                        or is a NULL pointer.
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
- * @retval HDMI_CEC_IO_INVALID_OUTPUT   - Physical address cannot be retrieved. This includes:
- *                                        the HDMI cable is not connected (source devices),
- *                                        physical address discovery is still in progress
- *                                        after an HDMI connect state change event, or the retrieved address
- *                                        is outside the valid range (0.0.0.0 to F.F.F.E).
+ * @retval HDMI_CEC_IO_INVALID_OUTPUT   - This API will return HDMI_CEC_IO_INVALID_OUTPUT if:
+ *                                        - The physical address cannot be retrieved, or
+ *                                        - The HDMI cable is not connected (source devices)
+ *                                        - The retrieved address is outside the valid range (0.0.0.0 to F.F.F.E)
+
  *
  * @pre HdmiCecOpen() must be called successfully before calling this API.
  *

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -78,7 +78,7 @@ typedef enum HDMI_CEC_IO_ERROR
     HDMI_CEC_IO_SENT_AND_ACKD = 1,          ///< Send and acknowledgement received
     HDMI_CEC_IO_SENT_BUT_NOT_ACKD,          ///< Sent but acknowledgement not received
     HDMI_CEC_IO_SENT_FAILED,                ///< Operation failed
-    HDMI_CEC_IO_NOT_OPENED,                 ///< Module is not open. will be removed in a future release.
+    HDMI_CEC_IO_NOT_OPENED,                 ///< Module is not initialised
     HDMI_CEC_IO_INVALID_ARGUMENT,           ///< Invalid argument is passed to the module
     HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE, ///< Logical address is not available
     HDMI_CEC_IO_GENERAL_ERROR,              ///< Operation general error.

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -159,21 +159,15 @@ HDMI_CEC_STATUS HdmiCecOpen(int *handle);
 /**
  * @brief Closes an instance of HDMI CEC HAL
  *
- * This function uninitialises the module, clears all registered logical addresses,
- * and deregisters all callbacks.@n
- * This function succeeds regardless of HDMI cable connection state for all device types.@n
- * For source devices, it is safe to call from an HPD (Hot Plug Detect) event handler;
- * middleware is expected to call HdmiCecClose() on every HPD event and reinitialise
- * from scratch via HdmiCecOpen().
+ * This function will uninitialise the module.@n
+ * Close will clear up registered logical addresses.@n
+ * Subsequent calls to this API will return HDMI_CEC_IO_NOT_OPENED.
  *
  * @param[in] handle - The handle returned from the HdmiCecOpen(). Non zero value
  *
  * @return HDMI_CEC_STATUS              - Status
  * @retval HDMI_CEC_IO_SUCCESS          - Success
- * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not open: HdmiCecOpen() was never called,
- *                                        the last HdmiCecOpen() did not return
- *                                        HDMI_CEC_IO_SUCCESS, or HdmiCecClose() has
- *                                        already been called successfully
+ * @retval HDMI_CEC_IO_NOT_OPENED       - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_HANDLE   - An invalid handle argument has been passed
  * @retval HDMI_CEC_IO_GENERAL_ERROR    - Unexpected platform-level failure
  *

--- a/include/hdmi_cec_driver.h
+++ b/include/hdmi_cec_driver.h
@@ -402,7 +402,9 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  *                    HDMI_CEC_IO_SENT_BUT_NOT_ACKD  - message sent but not acknowledged
  *                                                     (e.g. no device at the destination address)
  *                    HDMI_CEC_IO_SENT_FAILED         - message could not be sent
- *                                                     (e.g. bus collision or cable not connected)
+ *                                                     (e.g. bus collision, cable not connected,
+ *                                                     or platform did not confirm transmission
+ *                                                     within an implementation-defined timeout)
  *
  * @return HDMI_CEC_STATUS                        - API call status (check before inspecting result)
  * @retval HDMI_CEC_IO_SUCCESS                    - Transmission attempted; inspect result for
@@ -419,6 +421,8 @@ HDMI_CEC_STATUS HdmiCecSetTxCallback(int handle, HdmiCecTxCallback_t cbfunc, voi
  *                                                  return bus outcome directly instead of SUCCESS)
  * @retval HDMI_CEC_IO_SENT_FAILED                - Message could not be sent (platform may
  *                                                  return bus outcome directly instead of SUCCESS)
+ * @retval HDMI_CEC_IO_GENERAL_ERROR              - Underlying platform transport failed to
+ *                                                  initiate transmission; *result is undefined
  *
  * @pre  HdmiCecOpen() should be called before calling this API.
  * @warning  This API is Not thread safe.
@@ -447,6 +451,8 @@ HDMI_CEC_STATUS HdmiCecTx(int handle, const unsigned char *buf, int len, int *re
  * @retval HDMI_CEC_IO_NOT_OPENED                 - Module is not initialised
  * @retval HDMI_CEC_IO_INVALID_ARGUMENT           - Parameter passed to this function is invalid
  * @retval HDMI_CEC_IO_INVALID_HANDLE             - An invalid handle argument has been passed
+ * @retval HDMI_CEC_IO_GENERAL_ERROR              - Underlying platform transport failed to
+ *                                                  queue the message
  *
  * @pre  HdmiCecOpen(), HdmiCecSetRxCallback(), HdmiCecSetTxCallback()  should be called before calling this API.
  * @warning  This API is Not thread safe.


### PR DESCRIPTION
This PR addresses spec ambiguities and missing documentation in hdmi_cec_driver.h that were causing incorrect test assertions, integration misunderstandings, and undefined behaviour in real hardware scenarios. 

| ID | File | Section / API | Mandatory HAL Behavioral Requirement | Why (Clarity / Compliance) | Possible Failure if Not Followed |
|---|---|---|---|---|---|
| 1 | [`docs/pages/hdmi-cec_halSpec.md`](hdmi-cec_halSpec.md#theory-of-operation-and-key-concepts) | `HdmiCecOpen()` — error handling | If `HdmiCecOpen()` returns any error code, the HAL **must** release all resources allocated during the open operation before returning. The caller may safely retry without calling `HdmiCecClose()` first. | Prevents resource leaks on failure and defines deterministic retry behavior. | HAL is left in a partial-init state; caller retry leaks resources on each attempt, eventually exhausting memory or handles. |
| 2 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HDMI_CEC_IO_ALREADY_OPEN` | `HDMI_CEC_IO_ALREADY_OPEN` is deprecated but **must** still be returned on a repeated `HdmiCecOpen()` call. Returning `HDMI_CEC_IO_SUCCESS` with the previous handle is unsafe: the caller cannot determine whether the returned handle is new or the existing one, may call `HdmiCecClose()` once per perceived open, and freeing the same resources twice will cause a crash. Returning `HDMI_CEC_IO_ALREADY_OPEN` makes the repeat-open condition unambiguous and prevents double-close. | Prevents handle ambiguity and double-free crash from mismatched open/close call counts. | Caller tracks two apparent handles for one real resource; each `HdmiCecClose()` attempts to free the same underlying resources — the second call causes a double-free crash. |
| 3 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecRxCallback_t` | Each callback invocation **must** deliver exactly one complete CEC message. The HAL **must not** accumulate multiple messages per call. The caller **must** copy `buf` before the callback returns — the pointer is invalid after the callback exits. | Removes ambiguity around buffer lifetime and callback message-delivery contract. | Batching multiple messages in one call causes parse errors or message loss; accessing `buf` after callback return causes use-after-free and corrupted CEC data. |
| 4 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecTxCallback_t` | `HdmiCecTxCallback_t` is deprecated. The HAL **must not** introduce new mandatory dependencies on this callback. The `result` parameter is valid only for unicast transmissions; its value is undefined for broadcast messages. | Avoids misuse and clarifies transition away from the deprecated async-transmit callback pattern. | Caller reads undefined `result` for broadcast and incorrectly triggers retries or error recovery, causing silent protocol misbehavior. |
| 5 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecOpen()` — repeat-open | Subsequent calls to `HdmiCecOpen()` when the module is already initialized **must** return `HDMI_CEC_IO_ALREADY_OPEN`. The HAL **must not** return `HDMI_CEC_IO_SUCCESS` on a repeat open — doing so makes the returned handle indistinguishable from a new open, leading callers to call `HdmiCecClose()` for each perceived open. Freeing the same underlying resources twice causes a crash. The HAL **must not** re-initialize internal state on a repeat open. | Aligns behavior across implementations; prevents handle ambiguity and double-free on mismatched close calls. | Caller calls `HdmiCecClose()` for each `HDMI_CEC_IO_SUCCESS` return; second close frees already-freed resources and causes a crash or undefined behavior. |
| 6 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecOpen()` — source-device logical address | For source devices, `HdmiCecOpen()` **must** internally initiate logical address discovery as defined by the HDMI CEC specification. The discovered address **must** be retrievable via `HdmiCecGetLogicalAddress()` after `HdmiCecOpen()` returns `HDMI_CEC_IO_SUCCESS`. | Ensures interoperable source-device initialization without additional caller steps. | Caller has no valid logical address after open; all outgoing CEC messages use an invalid source address, causing other devices to ignore or misroute responses. |
| 7 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecOpen()` — source-device HDMI connect event | For source devices, the HAL **must** internally re-discover the logical address when an HDMI hotplug-in event is detected. The caller **must not** need to re-invoke `HdmiCecOpen()` to trigger rediscovery; a subsequent `HdmiCecGetLogicalAddress()` call after the event **must** return the newly assigned address. | Clarifies runtime behavior on reconnect and avoids unnecessary API re-initialization. | Caller re-invokes `HdmiCecOpen()` on reconnect, triggering unnecessary resource re-allocation or inadvertent state reset; or caller uses a stale logical address after reconnect, breaking CEC communication. |
| 8 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecOpen()` / `HdmiCecGetLogicalAddress()` — HDMI disconnect | After an HDMI disconnect event, the HAL **must** reset the logical address to `0x0F`. Calling `HdmiCecGetLogicalAddress()` while disconnected **must** return `0x0F`. | Defines a deterministic default state when the cable is removed. | Caller reads a stale logical address while disconnected and transmits CEC messages with an address no longer assigned; remote devices receive frames from an unexpected source. |
| 9 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecOpen()` — sink-device constraints | `HdmiCecOpen()` **must never** return `HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE` for sink devices. Logical address allocation for sink devices is the caller's responsibility via `HdmiCecAddLogicalAddress()`. | Separates source and sink responsibilities; prevents erroneous failure on sink init. | Sink initialization fails with `HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE` even on valid hardware where no CEC bus is required at open time; CEC stack never starts. |
| 10 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecClose()` — repeated close | Calling `HdmiCecClose()` on a handle that was never successfully opened, or after the module has already been closed, **must** return `HDMI_CEC_IO_NOT_OPENED`. An underlying platform failure during close **must** return `HDMI_CEC_IO_GENERAL_ERROR`. | Removes ambiguity in handle lifecycle; enables safe cleanup in error paths. | A second close silently returns `HDMI_CEC_IO_SUCCESS`, masking the invalid-handle condition; caller believes cleanup succeeded and proceeds with a dangling handle. |
| 11 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecAddLogicalAddress()` — device-type restriction | `HdmiCecAddLogicalAddress()` is applicable to sink devices only. Invoking this API on a source device **must** return `HDMI_CEC_IO_OPERATION_NOT_SUPPORTED`. | Enforces role-specific API contract; prevents misuse on source devices. | Source device silently accepts a caller-assigned logical address that conflicts with the internally discovered one; CEC bus sees duplicate logical addresses, causing message collisions. |
| 12 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecAddLogicalAddress()` — valid addresses and return codes | For sink devices, valid logical address values are `0` (TV), `14` (Specific Use), and `15` (Unregistered fallback) as defined by the HDMI CEC specification. Any other value **must** return `HDMI_CEC_IO_INVALID_ARGUMENT`. If the CEC bus is unavailable to send the POLL message, the HAL **must** return `HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE`. | Reduces implementation divergence and defines clear validation and bus-failure behavior. | Invalid address accepted silently leads to undefined CEC bus behavior; missing `HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE` means address conflicts go undetected and the caller cannot handle bus-unavailable conditions. |
| 13 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecRemoveLogicalAddress()` — postconditions | After a successful release, the HAL **must** set the logical address to `0x0F` and **must** stop ACKing any POLL message destined to the released address. Calling this API on a source device **must** return `HDMI_CEC_IO_OPERATION_NOT_SUPPORTED`. | Makes release semantics explicit and testable for both device types. | HAL continues ACKing POLL on the released address; other CEC devices believe the address is still active, causing address allocation failures for other devices attempting to claim it. |
| 14 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecGetLogicalAddress()` — default and disconnected state | For sink devices with no address added or after removal, the HAL **must** return logical address `0x0F`. For source devices, the HAL **must** return the HDMI-spec-defined address for the device type, or `0x0F` when disconnected. | Ensures consistent readout semantics across all initialization and connection states. | Caller reads a stale or garbage logical address and embeds it as the CEC source address in outgoing messages while the address is invalid; messages are silently dropped or misrouted by receiving devices. |
| 15 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecGetPhysicalAddress()` — sink and source behavior | Sink devices **must** return fixed PA `0.0.0.0`. Source devices **must** re-discover the physical address on HDMI connect and **must** return `HDMI_CEC_IO_INVALID_OUTPUT` until discovery completes or while disconnected. Valid PA range is `0.0.0.0` to `F.F.F.E`; any address outside this range is an invalid output. | Establishes deterministic PA behavior and defines clear validation criteria. | Source device returns a stale PA from a previous connection; CEC routing breaks silently. Sink returns a dynamic PA that changes on hotplug, making it impossible for other devices to address it consistently. |
| 16 | [`include/hdmi_cec_driver.h`](../../include/hdmi_cec_driver.h) | `HdmiCecTx()` — synchronous result semantics | For unicast messages, `result` **must** reflect the actual ACK/NACK outcome from the CEC bus. For broadcast messages, `result` is undefined and the caller **must not** rely on it. If the CEC bus is absent, the function **must** return `HDMI_CEC_IO_SENT_FAILED`. | Improves caller-side error handling and removes ambiguity around broadcast and absent-bus cases. | Caller interprets undefined broadcast `result` as ACK/NACK and triggers incorrect retry or error recovery; absent bus not signaled causes the caller to block or silently drop the failure, with no path to recover. |

---

## Improvements

| # | API | Improvement |
|---|-----|-------------|
| 1 | `HdmiCecOpen()` | Clarify that a valid handle is returned **only** on `HDMI_CEC_IO_SUCCESS`; calling `HdmiCecClose()` on any other return code is invalid |
| 2 | `HdmiCecOpen()` | Fix misleading "Subsequent calls return `HDMI_CEC_IO_SUCCESS`" — correct behaviour is `HDMI_CEC_IO_ALREADY_OPEN` |
| 3 | `HdmiCecOpen()` | Expand `HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE` to cover all device types when CEC bus is absent, not only source devices |
| 4 | `HdmiCecOpen()` | Add missing `@retval HDMI_CEC_IO_GENERAL_ERROR`; mark `HDMI_CEC_IO_ALREADY_OPEN` as deprecated |
| 5 | `HdmiCecClose()` | Document that close deregisters all callbacks and succeeds regardless of cable state (safe to call from HPD handler) |
| 6 | `HdmiCecClose()` | Fix contradiction: `HDMI_CEC_IO_NOT_OPENED` is only returned before any successful open; repeated close calls return `HDMI_CEC_IO_SUCCESS` |
| 7 | `HdmiCecClose()` | Add missing `@retval HDMI_CEC_IO_GENERAL_ERROR` |
| 8 | `HdmiCecAddLogicalAddress()` | Add missing `@retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE` (no CEC bus to send POLL) and `HDMI_CEC_IO_GENERAL_ERROR` |
| 9 | `HdmiCecRemoveLogicalAddress()` | Clarify `HDMI_CEC_IO_NOT_ADDED` covers both "never added" and "already removed"; add missing `HDMI_CEC_IO_GENERAL_ERROR` |
| 10 | `HdmiCecGetLogicalAddress()` | Specify hot-unplug behaviour for source devices; add missing `@retval HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE` |
| 11 | `HdmiCecGetPhysicalAddress()` | Tie `HDMI_CEC_IO_INVALID_OUTPUT` explicitly to the HDMI 1.4b unassigned sentinel `0xF.F.F.F` (0xFFFF) and hot-unplug case |
| 12 | `HdmiCecSetRxCallback()` / `HdmiCecSetTxCallback()` | Document callback lifecycle: deregistered by `HdmiCecClose()`, must be re-registered after `HdmiCecOpen()`; add missing `@retval HDMI_CEC_IO_INVALID_ARGUMENT` to `SetTxCallback` |
| 13 | `HdmiCecTx()` | Clarify `result` out-parameter is undefined for broadcast messages; document absent-bus → `HDMI_CEC_IO_SENT_FAILED` |

---

## Acceptance Criteria

- All `@retval` entries match the error codes exercised by L1/L2/L3 tests
- `HdmiCecClose()` idempotency and HPD-safety are explicitly stated
- Handle validity contract (`HDMI_CEC_IO_SUCCESS` only) is unambiguous
- No spec statement contradicts another

---

## Note
